### PR TITLE
++ system contract mocks to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Hedera Smart Contract Service supporting files",
   "files": [
     "/contracts/**/*.sol",
-    "/contracts/**/**/**/*.sol"
+    "/contracts/**/**/**/*.sol",
+    "/test/foundry/mocks/**/*.sol",
+    "/test/foundry/mocks/**/**/**/*.sol"
   ],
   "repository": {
     "type": "git",

--- a/test/foundry/mocks/hts-precompile/HtsSystemContractMock.sol
+++ b/test/foundry/mocks/hts-precompile/HtsSystemContractMock.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.9;
 
-import 'forge-std/console.sol';
-
 import '../../../../contracts/hts-precompile/HederaResponseCodes.sol';
 import '../../../../contracts/hts-precompile/KeyHelper.sol';
 import './HederaFungibleToken.sol';


### PR DESCRIPTION
Add the mocks to `files` so that they're downloaded when the `hedera-smart-contracts` is installed as a dependency in a hardhat project